### PR TITLE
Refactorings/remove obsolete code

### DIFF
--- a/apps/_example03ant/next.config.js
+++ b/apps/_example03ant/next.config.js
@@ -1,9 +1,5 @@
 const withLess = require('@zeit/next-less')
 
-// fix: prevents error when .less files are required by node
-if (typeof require !== 'undefined') {
-    require.extensions['.less'] = () => {}
-}
 module.exports = withLess({
     lessLoaderOptions: {
         javascriptEnabled: true,

--- a/apps/_pomodoro_app/next.config.js
+++ b/apps/_pomodoro_app/next.config.js
@@ -1,9 +1,5 @@
 const withLess = require('@zeit/next-less')
 
-// fix: prevents error when .less files are required by node
-if (typeof require !== 'undefined') {
-    require.extensions['.less'] = () => {}
-}
 module.exports = withLess({
     lessLoaderOptions: {
         javascriptEnabled: true,


### PR DESCRIPTION
Obsolete code was taken from the old version of `next.js` (they actually advised to use this code back in a day) and can be safely removed. 

`yarn workspace @app/_example03 dev` launches just fine, and displays `.less` styling accordingly 

Here we can find some information about the bug
https://github.com/zeit/next.js/issues/6181
https://github.com/zeit/next.js/issues/8054
